### PR TITLE
fix(windows): convert path to file url

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,4 +1,3 @@
-import { readFile, rm } from 'fs/promises'
 import * as fs from 'fs/promises'
 import path from 'path'
 import axios, { isAxiosError } from 'axios'
@@ -49,7 +48,7 @@ export class CommandPublish {
 
     try {
       const pkg = JSON.parse(
-        await readFile(path.join(repoDir, 'package.json'), 'utf-8')
+        await fs.readFile(path.join(repoDir, 'package.json'), 'utf-8')
       )
       const repository = this.getRepositoryId(pkg)
 
@@ -65,7 +64,7 @@ export class CommandPublish {
       await this.uploadTarball(pkg, filePath, repository!, dryrun)
 
       // Step 4 - Clean up the created tarball file
-      await rm(filePath, { force: true })
+      await fs.rm(filePath, { force: true })
       logger.info('Cleaned up temporary tarball')
 
       logger.info(`Successfully published ${pkg.name}@${pkg.version}`)
@@ -196,7 +195,7 @@ export class CommandPublish {
     const stats = await fs.stat(tarballPath)
 
     if (stats.size > PACKAGE_MAX_SIZE) {
-      await rm(tarballPath, { force: true })
+      await fs.rm(tarballPath, { force: true })
       throw new Error(
         `Package tarball size (${(stats.size / 1024 / 1024).toFixed(2)}MB) exceeds the 30MB limit`
       )

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,6 +1,7 @@
 import { rm } from 'fs/promises'
 import * as fs from 'fs/promises'
 import path from 'path'
+import { pathToFileURL } from 'url'
 import axios, { isAxiosError } from 'axios'
 import FormData from 'form-data'
 import * as tar from 'tar'
@@ -49,7 +50,7 @@ export class CommandPublish {
 
     try {
       const { default: pkg } = await import(
-        path.join(repoDir, 'package.json'),
+        pathToFileURL(path.join(repoDir, 'package.json')).href,
         { with: { type: 'json' } }
       )
       const repository = this.getRepositoryId(pkg)

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,7 +1,6 @@
-import { rm } from 'fs/promises'
+import { readFile, rm } from 'fs/promises'
 import * as fs from 'fs/promises'
 import path from 'path'
-import { pathToFileURL } from 'url'
 import axios, { isAxiosError } from 'axios'
 import FormData from 'form-data'
 import * as tar from 'tar'
@@ -49,9 +48,8 @@ export class CommandPublish {
     const repoDir = packagePath || process.cwd()
 
     try {
-      const { default: pkg } = await import(
-        pathToFileURL(path.join(repoDir, 'package.json')).href,
-        { with: { type: 'json' } }
+      const pkg = JSON.parse(
+        await readFile(path.join(repoDir, 'package.json'), 'utf-8')
       )
       const repository = this.getRepositoryId(pkg)
 


### PR DESCRIPTION
This pull request makes a minor update to the way the `package.json` file is imported in the `CommandPublish` class. The change ensures the file path is properly converted to a file URL before importing, which improves compatibility and reliability.

- Updated `CommandPublish` to use `pathToFileURL` when importing `package.json`, ensuring correct file URL formatting. [[1]](diffhunk://#diff-adc8934db1a646fd72f3cdda4ede76ecfc3628ec0f8dd1f37403d0121183e94aR4) [[2]](diffhunk://#diff-adc8934db1a646fd72f3cdda4ede76ecfc3628ec0f8dd1f37403d0121183e94aL52-R53)

@Keisir can you review it?